### PR TITLE
chunked ohttp support in ohttp library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ run-server-attest: ca
 		--attest --maa_url ${MAA} --kms_url ${KMS}
 
 run-server-container: 
+	docker run --privileged -e TARGET=${TARGET} -e INSTANCE_SPECIFIC_KEY=1 --net=host  ohttp-server
+
+run-server-container-attest: 
 	docker run --privileged -e TARGET=${TARGET}  --net=host --mount type=bind,source=/sys/kernel/security,target=/sys/kernel/security  --device /dev/tpmrm0  ohttp-server
 
 run-whisper:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ TARGET ?= http://127.0.0.1:3000
 TARGET_PATH ?= '/whisper'
 INPUT ?= ./examples/audio.mp3
 
-
 ca:
 	./ohttp-server/ca.sh
 
@@ -33,10 +32,10 @@ run-server-attest: ca
 		--attest --maa_url ${MAA} --kms_url ${KMS}
 
 run-server-container: 
-	docker run --privileged -e TARGET=${TARGET} -e INSTANCE_SPECIFIC_KEY=1 --net=host  ohttp-server
+	docker compose -f ./docker/docker-compose-server.yml up
 
 run-server-container-attest: 
-	docker run --privileged -e TARGET=${TARGET}  --net=host --mount type=bind,source=/sys/kernel/security,target=/sys/kernel/security  --device /dev/tpmrm0  ohttp-server
+	docker run --privileged -e TARGET=${TARGET} --net=host --mount type=bind,source=/sys/kernel/security,target=/sys/kernel/security  --device /dev/tpmrm0  ohttp-server
 
 run-whisper:
 	docker run --network=host whisper-api 

--- a/docker/docker-compose-faster-whisper.yml
+++ b/docker/docker-compose-faster-whisper.yml
@@ -6,6 +6,7 @@ services:
     network_mode: "host"
     environment:
       - TARGET=http://localhost:8000
+      - INSTANCE_SPECIFIC_KEY=1
     depends_on:
       - whisper
 

--- a/docker/docker-compose-http.yml
+++ b/docker/docker-compose-http.yml
@@ -6,7 +6,7 @@ services:
       - "9443:9443"
     environment:
       - TARGET=http://localhost:5678
-
+      - INSTANCE_SPECIFIC_KEY=1
   web_service:
     image: otomato/http-echo
     command:

--- a/docker/docker-compose-server.yml
+++ b/docker/docker-compose-server.yml
@@ -7,11 +7,3 @@ services:
     environment:
       - TARGET=http://localhost:3000
       - INSTANCE_SPECIFIC_KEY=1
-    depends_on:
-      - web_service
-
-  web_service:
-    image: nodejs-streaming
-    network_mode: "host"
-    ports:
-      - "3000:3000"

--- a/docker/docker-compose-whisper.yml
+++ b/docker/docker-compose-whisper.yml
@@ -6,6 +6,7 @@ services:
     network_mode: "host"
     environment:
       - TARGET=http://localhost:3000
+      - INSTANCE_SPECIFIC_KEY=1
     depends_on:
       - whisper
 

--- a/docker/server/run.sh
+++ b/docker/server/run.sh
@@ -23,4 +23,5 @@ if [[ ${KMS_URL} ]]; then
 fi
 
 # Run OHTTP server
-`$CMD`
+echo "Running $CMD..."
+eval $CMD

--- a/docker/server/run.sh
+++ b/docker/server/run.sh
@@ -1,26 +1,54 @@
 #!/bin/bash
 
+is_valid_url() {
+    local url="$1"
+
+    # Regular expression to validate the URL
+    local regex='^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/.*)?$'
+
+    if [[ $url =~ $regex ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 if [[ -z ${TARGET} ]]; then
   echo "No TARGET defined"
   exit 1
 fi
 
-# Generate certificate for TLS
-/usr/local/bin/ca.sh
-
-CMD="/usr/local/bin/ohttp-server --certificate /usr/local/bin/server.crt --key /usr/local/bin/server.key --target $TARGET"
+if is_valid_url $TARGET; then 
+  CMD="RUST_LOG=info /usr/local/bin/ohttp-server --certificate /usr/local/bin/server.crt --key /usr/local/bin/server.key --target $TARGET"
+else
+  echo "TARGET is not a valid URL"
+  exit 1
+fi
 
 if [[ -z ${INSTANCE_SPECIFIC_KEY} ]]; then
    CMD="$CMD --attest"
 fi
 
-if [[ ${MAA_URL} ]]; then 
-  CMD="$CMD --maa_url ${MAA_URL}"
+if [[ -n ${MAA_URL} ]]; then 
+  if is_valid_url $MAA_URL; then 
+    CMD="$CMD --maa_url ${MAA_URL}"
+  else 
+    echo "MAA_URL is not a valid URL"
+    exit 1
+  fi
 fi
 
-if [[ ${KMS_URL} ]]; then 
-  CMD="$CMD --kms_url ${KMS_URL}"
+if [[ -n ${KMS_URL} ]]; then 
+  if is_valid_url $KMS_URL; then 
+    CMD="$CMD --kms_url ${KMS_URL}"
+  else 
+    echo "KMS_URL is not a valid URL"
+    exit 1
+  fi
 fi
+
+# Generate certificate for TLS
+/usr/local/bin/ca.sh
 
 # Run OHTTP server
 echo "Running $CMD..."

--- a/ohttp-client/Cargo.toml
+++ b/ohttp-client/Cargo.toml
@@ -17,6 +17,8 @@ reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"
 rustls = { version = "0.21.6", features = ["dangerous_configuration"] }
 structopt = "0.3"
 tokio = { version = "1", features = ["full"] }
+futures-util = "0.3.30"
+futures = "0.3.30"
 
 [dependencies.bhttp]
 path= "../bhttp"

--- a/ohttp-client/Cargo.toml
+++ b/ohttp-client/Cargo.toml
@@ -19,6 +19,7 @@ structopt = "0.3"
 tokio = { version = "1", features = ["full"] }
 futures-util = "0.3.30"
 futures = "0.3.30"
+log = "0.4.22"
 
 [dependencies.bhttp]
 path= "../bhttp"

--- a/ohttp-server/Cargo.toml
+++ b/ohttp-server/Cargo.toml
@@ -24,6 +24,7 @@ warp = { version = "0.3", features = ["tls"] }
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }
 futures-util = "0.3.30"
 futures = "0.3.30"
+log = "0.4.22"
 
 [dependencies.bhttp]
 path= "../bhttp"

--- a/ohttp/Cargo.toml
+++ b/ohttp/Cargo.toml
@@ -45,6 +45,7 @@ thiserror = "1"
 futures-util = "0.3.30"
 futures = "0.3.30"
 bytes = "1.7.2"
+async-stream = "0.3.5"
 
 [dependencies.hpke-pq]
 package = "hpke_pq"

--- a/ohttp/Cargo.toml
+++ b/ohttp/Cargo.toml
@@ -42,6 +42,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = {version = "0.9", optional = true}
 thiserror = "1"
+futures-util = "0.3.30"
+futures = "0.3.30"
+bytes = "1.7.2"
 
 [dependencies.hpke-pq]
 package = "hpke_pq"

--- a/ohttp/src/lib.rs
+++ b/ohttp/src/lib.rs
@@ -337,10 +337,11 @@ impl ServerResponse {
         Ok(enc_response)
     }
 
-    pub async fn encapsulate_stream<S, E>(&mut self, input: S) -> 
-        std::pin::Pin<Box<dyn Stream<Item = Res<Vec<u8>>> + Send>>
+    // Consume this object by encapsulating a stream
+    pub fn encapsulate_stream<S, E>(mut self, input: S) -> 
+        std::pin::Pin<Box<dyn Stream<Item = Res<Vec<u8>>> + Send + 'static>>
     where
-        S: Stream<Item = Result<Vec<u8>, E>> + Send,
+        S: Stream<Item = Result<Vec<u8>, E>> + Send + 'static,
         E: std::fmt::Debug + Send
     {
         let response_nonce = self.response_nonce();
@@ -362,7 +363,7 @@ impl ServerResponse {
             stream::iter(encapsulated_chunks)
         });
         let stream = nonce_stream.chain(output_stream);
-        Box::pin(stream::iter(stream.collect::<Vec<_>>().await))
+        Box::pin(stream)
     }
 }
 


### PR DESCRIPTION
This PR introduces new APIs in the OHTTP library to support [chunked OHTTP](https://www.ietf.org/archive/id/draft-ohai-chunked-ohttp-01.html). 

- ```encapsulate_stream``` in ```ServerResponse``` encapsulates a stream of chunks (vector of bytes). It returns a stream of encapsulated chunks in chunked OHTTP format. This includes a nonce, non-final chunks, final chunk indicator, and a final chunk. 
- ```decapsulate_stream``` in ```ClientResponse``` decapsulates an encapsulated stream. 

The PR also includes changes to ohttp server and client to use these APIs. This requires turning an HTTP chunked response into a stream. 

Additional changes:
- URL validation in container startup script
- Consistent tracing using log crate. 
