### PR TITLE
Add structured logging

### DIFF
--- a/ohttp-server/Cargo.toml
+++ b/ohttp-server/Cargo.toml
@@ -24,6 +24,7 @@ warp = { version = "0.3", features = ["tls"] }
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }
 futures-util = "0.3.30"
 futures = "0.3.30"
+serde_with = "1.10"
 
 [dependencies.bhttp]
 path= "../bhttp"


### PR DESCRIPTION
Add structured logging for telemetry 

Args : {"address":"127.0.0.1:9443","indeterminate":false,"certificate":"./ohttp-server/server.crt","key":"./ohttp-server/server.key","target":"http://127.0.0.1:3000/","attest":false,"maa_url":null,"kms_url":null}
Config : "002d0000203718062a75e406352e10b6b57cc19eeb6b880ab1c9e21c8f8fac6638251f462000080001000100010003"
Processing chunk : {"first":true,"chunk":"{\"results\":[{\"filename\":\"file\",\"transcript\":\" The quick brown fox jumped over a dog.\"}]}\n"}
Processing chunk : {"first":false,"chunk":""}