### PR TITLE
client support for curl like flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,10 @@ TARGET ?= http://127.0.0.1:3000
 TARGET_PATH ?= '/whisper'
 INPUT ?= ./examples/audio.mp3
 
-
-ca:
-	./ohttp-server/ca.sh
-
 build-whisper:
 	docker build -f docker/whisper/Dockerfile -t whisper-api ./docker/whisper
 
-build-server: ca
+build-server:
 	docker build -f docker/server/Dockerfile -t ohttp-server .
 
 build-client:
@@ -23,16 +19,18 @@ build-streaming:
 
 build: build-server build-client build-streaming build-whisper
 
-run-server: ca
-	cargo run --bin ohttp-server -- --certificate ./ohttp-server/server.crt \
-		--key ./ohttp-server/server.key --target ${TARGET} 
+run-server:
+	cargo run --bin ohttp-server -- --target ${TARGET} 
 
-run-server-attest: ca
+run-server-attest:
 	cargo run --bin ohttp-server -- --certificate ./ohttp-server/server.crt \
 		--key ./ohttp-server/server.key --target ${TARGET} \
 		--attest --maa_url ${MAA} --kms_url ${KMS}
 
 run-server-container: 
+	docker compose -f ./docker/docker-compose-server.yml up
+	
+run-server-container-attest: 
 	docker run --privileged -e TARGET=${TARGET}  --net=host --mount type=bind,source=/sys/kernel/security,target=/sys/kernel/security  --device /dev/tpmrm0  ohttp-server
 
 run-whisper:
@@ -53,13 +51,12 @@ service-cert:
 verify-quote:
 	verify_quote.sh ${KMS} --cacert service_cert.pem
 	
-run-client-kms: ca service-cert verify-quote
-	cargo run --bin ohttp-client -- --trust ./ohttp-server/ca.crt \
-  'https://localhost:9443/score' --target-path ${TARGET_PATH} -i ${INPUT} \
+run-client-kms: service-cert verify-quote
+	cargo run --bin ohttp-client -- 'http://localhost:9443/score'\
+  --target-path ${TARGET_PATH} -F "file=@${INPUT}" \
   --kms-cert ./service_cert.pem 
 
-run-client-local: ca
-	cargo run --bin ohttp-client -- --trust ./ohttp-server/ca.crt \
-  'https://localhost:9443/score' --target-path ${TARGET_PATH} -i ${INPUT} \
-  --config `curl -s -k https://localhost:9443/discover` --api-key test123
-
+run-client-local:
+	RUST_LOG=info cargo run --bin ohttp-client -- 'http://localhost:9443/score'\
+  --target-path ${TARGET_PATH} -F "file=@${INPUT}" \
+  -H "api-key: test123" --config `curl -s http://localhost:9443/discover` 

--- a/docker/docker-compose-server.yml
+++ b/docker/docker-compose-server.yml
@@ -1,0 +1,9 @@
+services:
+  server:
+    image: ohttp-server
+    ports:
+      - "9443:9443"
+    network_mode: "host"
+    environment:
+      - TARGET=http://localhost:3000
+      - INSTANCE_SPECIFIC_KEY=1

--- a/docker/server/run.sh
+++ b/docker/server/run.sh
@@ -5,10 +5,7 @@ if [[ -z ${TARGET} ]]; then
   exit 1
 fi
 
-# Generate certificate for TLS
-/usr/local/bin/ca.sh
-
-CMD="/usr/local/bin/ohttp-server --certificate /usr/local/bin/server.crt --key /usr/local/bin/server.key --target $TARGET"
+CMD="/usr/local/bin/ohttp-server --target $TARGET"
 
 if [[ -z ${INSTANCE_SPECIFIC_KEY} ]]; then
    CMD="$CMD --attest"

--- a/ohttp-client/Cargo.toml
+++ b/ohttp-client/Cargo.toml
@@ -10,12 +10,13 @@ nss = ["ohttp/nss"]
 rust-hpke = ["ohttp/rust-hpke"]
 
 [dependencies]
+clap = { version = "4.5.18", features = ["derive"] }
 colored = "2.1.0"
 env_logger = {version = "0.10", default-features = false}
 hex = "0.4"
+log = "0.4.22"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 rustls = { version = "0.21.6", features = ["dangerous_configuration"] }
-structopt = "0.3"
 tokio = { version = "1", features = ["full"] }
 
 [dependencies.bhttp]

--- a/ohttp-client/src/main.rs
+++ b/ohttp-client/src/main.rs
@@ -5,8 +5,9 @@ use std::{
     fs::{self, File}, io::{self, Read, Write}, ops::Deref, path::PathBuf, str::FromStr
 };
 use std::io::Cursor;
-use structopt::StructOpt;
+use clap::Parser;
 use reqwest::Client;
+use log::info;
 
 type Res<T> = Result<T, Box<dyn std::error::Error>>;
 
@@ -28,8 +29,8 @@ impl Deref for HexArg {
     }
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "ohttp-client", about = "Make an oblivious HTTP request.")]
+#[derive(Debug, Parser)]
+#[command(version = "0.1", about = "Make an oblivious HTTP request.")]
 struct Args {
     /// The URL of an oblivious proxy resource.
     /// If you use an oblivious request resource, this also works, though
@@ -37,45 +38,45 @@ struct Args {
     url: String,
 
     /// Target path of the oblivious resource
-    #[structopt(long, short = "p")]
+    #[arg(long, short = 'p')]
     target_path: String,
 
     /// key configuration
-    #[structopt(long, short = "c")]
+    #[arg(long, short = 'c')]
     config: Option<HexArg>,
 
     /// json containing the key configuration along with proof
-    #[structopt(long, short = "f")]
+    #[arg(long, short = 'f')]
     kms_url: Option<String>,
 
     /// Trusted KMS service certificate
-    #[structopt(long, short = "k")]
+    #[arg(long, short = 'k')]
     kms_cert: Option<PathBuf>,
-
-    /// Where to read request content.
-    /// If you omit this, input is read from `stdin`.
-    #[structopt(long, short = "i")]
-    input: Option<PathBuf>,
 
     /// Where to write response content.
     /// If you omit this, output is written to `stdout`.
-    #[structopt(long, short = "o")]
+    #[arg(long, short = 'o')]
     output: Option<PathBuf>,
 
     /// Read and write as binary HTTP messages instead of text.
-    #[structopt(long, short = "b")]
+    #[arg(long, short = 'b')]
     binary: bool,
 
     /// When creating message/bhttp, use the indeterminate-length form.
-    #[structopt(long, short = "n", alias = "indefinite")]
+    #[arg(long, short = 'n', alias = "indefinite")]
     indeterminate: bool,
 
-    /// Enable override for the trust store.
-    #[structopt(long)]
-    trust: Option<PathBuf>,
+    /// List of headers in the outer request
+    #[arg(long, short = 'H')]
+    headers: Option<Vec<String>>,
 
-    #[structopt(long, short = "a")]
-    api_key: Option<String>
+    /// List of headers in the outer request
+    #[arg(long, short = 'F')]
+    form_fields: Option<Vec<String>>,
+
+    /// List of headers in the outer request
+    #[arg(long, short = 'O')]
+    outer_headers: Option<Vec<String>>,
 }
 
 impl Args {
@@ -89,60 +90,56 @@ impl Args {
 }
 
 // Create a multi-part request from a file
-fn create_multipart_request(target_path: &str, file: &PathBuf) -> Res<Vec<u8>> {
+fn create_multipart_request(target_path: &str, headers: Option<Vec<String>>, fields: Option<Vec<String>>) -> Res<Vec<u8>> {
     // Define boundary for multipart
     let boundary = "----ConfidentialInferencingFormBoundary7MA4YWxkTrZu0gW";
 
-    // Load audio file
-    let mut file = File::open(file)?;
-    let mut file_contents = Vec::new();
-    file.read_to_end(&mut file_contents)?;
+    let mut request = Vec::new();
+    write!(&mut request, "POST {} HTTP/1.1\r\n", target_path)?;
+
+    if let Some(headers) = headers {
+        for header in headers {
+            write!(&mut request, "{}\r\n", header)?;
+        }
+    }
 
     // Create multipart body
     let mut body = Vec::new();
 
-    // Add the file
-    write!(
-        &mut body,
-        "--{}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"audio.mp3\"\r\nContent-Type: {}\r\n\r\n",
-        boundary,
-        "audio/mp3"
-    )?;
-    body.extend_from_slice(&file_contents);
-    write!(&mut body, "\r\n--{}--\r\n", boundary)?;
+    if let Some(fields) = fields {
+        for field in fields {
+            let mut parts = field.splitn(2, '=');
+            let name = parts.next().unwrap();
+            let value = parts.next().unwrap();
 
-    // Add the response format
-    write!(
-        &mut body,
-        "\r\nContent-Disposition: form-data; name=\"response_format\"\r\n\r\n",
-    )?;
-    write!(&mut body, "verbose_json")?;
-    write!(&mut body, "\r\n--{}--\r\n", boundary)?;
+            if value.starts_with('@') {
+                let filename = value.strip_prefix('@').unwrap();
+                let mut file = File::open(filename)?;
+                let mut file_contents = Vec::new();
+                file.read_to_end(&mut file_contents)?;
 
-    // Add the model
-    write!(
-        &mut body,
-        "\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\n",
-    )?;
-    write!(&mut body, "whisper-3")?;
-    write!(&mut body, "\r\n--{}--\r\n", boundary)?;
-
-    // Add language
-    write!(
-        &mut body,
-        "\r\nContent-Disposition: form-data; name=\"language\"\r\n\r\n",
-    )?;
-    write!(&mut body, "en")?;
-    write!(&mut body, "\r\n--{}--\r\n", boundary)?;
+                // Add the file
+                write!(
+                    &mut body,
+                    "--{}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"{}\"\r\nContent-Type: {}\r\n\r\n",
+                    boundary, filename, "audio/mp3"
+                )?;
+                body.extend_from_slice(&file_contents);
+            } else {
+                write!(&mut body, "\r\nContent-Disposition: form-data; name=\"{}\"\r\n\r\n", name)?;
+                write!(&mut body, "{}", value)?;
+            }
+            write!(&mut body, "\r\n--{}--\r\n", boundary)?;
+        }
+    }
     
-    let mut request = Vec::new();
-    write!(&mut request, "POST {} HTTP/1.1\r\n", target_path)?;
-    write!(&mut request, "openai-internal-authtoken: \"testtoken\"\r\n")?;
-    write!(&mut request, "openai-internal-enableasrsupport: \"true\"\r\n")?;
     write!(&mut request, "Content-Type: multipart/form-data; boundary={}\r\n", boundary)?;
     write!(&mut request, "Content-Length: {}\r\n", body.len())?;
     write!(&mut request, "\r\n")?;
+    info!("Sending request\n{}", std::str::from_utf8(&request).unwrap());
+    io::stdout().write_all(&body).unwrap();
     request.append(&mut body);
+
     Ok(request)
 }
 
@@ -168,28 +165,21 @@ async fn get_kms_config(kms_url: String, cert: &str) -> Res<String> {
 
 #[tokio::main]
 async fn main() -> Res<()> {
-    let args = Args::from_args();
+    let args = Args::parse();
     ::ohttp::init();
     env_logger::try_init().unwrap();
 
     println!("\n================== STEP 1 ==================");
 
-    let request = if let Some(infile) = &args.input {
-        let request = create_multipart_request(&args.target_path, infile)?;
+    let request = { 
+        let form_fields = args.form_fields.clone();
+        let headers = args.headers.clone();
+        let request = create_multipart_request(&args.target_path, headers, form_fields)?;
         let mut cursor = Cursor::new(request);
         if args.binary {
             Message::read_bhttp(&mut cursor)?
         } else {
             Message::read_http(&mut cursor)?
-        }
-    } else {
-        let mut buf = Vec::new();
-        std::io::stdin().read_to_end(&mut buf)?;
-        let mut r = io::Cursor::new(buf);
-        if args.binary {
-            Message::read_bhttp(&mut r)?
-        } else {
-            Message::read_http(&mut r)?
         }
     };
 
@@ -207,28 +197,23 @@ async fn main() -> Res<()> {
     };
 
     println!("\n================== STEP 2 ==================");
+    
     let (enc_request, mut ohttp_response) = ohttp_request.encapsulate(&request_buf)?;
     println!("Sending encrypted OHTTP request to {}: {}", args.url, hex::encode(&enc_request[0..60]));
 
-    let client = match &args.trust {
-        Some(pem) => {
-            let mut buf = Vec::new();
-            File::open(pem)?.read_to_end(&mut buf)?;
-            let cert = reqwest::Certificate::from_pem(buf.as_slice())?;
-            reqwest::ClientBuilder::new()
-                .danger_accept_invalid_certs(true)
-                .add_root_certificate(cert)
-                .build()?
-        }
-        None => reqwest::ClientBuilder::new().danger_accept_invalid_certs(true).build()?,
-    };
+    let client = reqwest::ClientBuilder::new().build()?;
 
     let mut builder = client
         .post(&args.url)
         .header("content-type", "message/ohttp-chunked-req");
 
-    if let Some(key) = &args.api_key {
-        builder = builder.header("api-key", key)
+    // Add outer headers
+    let outer_headers = args.outer_headers.clone();
+    if let Some(headers) =  outer_headers {
+        for header in headers {
+            let mut parts = header.splitn(2, ':');
+            builder = builder.header(parts.next().unwrap(), parts.next().unwrap());
+        }
     }
     
     let mut response = builder

--- a/ohttp-server/Cargo.toml
+++ b/ohttp-server/Cargo.toml
@@ -12,7 +12,6 @@ rust-hpke = ["ohttp/rust-hpke"]
 [dependencies]
 env_logger = {version = "0.10", default-features = false}
 hex = "0.4"
-structopt = "0.3"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 elliptic-curve = { version = "0.13.8", features = ["jwk"] }
@@ -24,6 +23,7 @@ warp = { version = "0.3", features = ["tls"] }
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }
 futures-util = "0.3.30"
 futures = "0.3.30"
+clap = { version = "4.5.18", features = ["derive"] }
 
 [dependencies.bhttp]
 path= "../bhttp"

--- a/ohttp-server/src/main.rs
+++ b/ohttp-server/src/main.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::pedantic)]
 
-use std::{io::Cursor, net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{io::Cursor, net::SocketAddr, sync::Arc};
 
 use futures::StreamExt;
 use futures_util::stream::{once, unfold};
@@ -15,7 +15,7 @@ use ohttp::{
     hpke::{Aead, Kdf, Kem},
     KeyConfig, Server as OhttpServer, ServerResponse, SymmetricSuite,
 };
-use structopt::StructOpt;
+use clap::Parser;
 use warp::hyper::Body;
 use warp::Filter;
 
@@ -45,39 +45,31 @@ struct ExportedKey {
 const DEFAULT_KMS_URL: &str = "https://acceu-aml-504.confidential-ledger.azure.com/key";
 const DEFAULT_MAA_URL: &str = "https://sharedeus2.eus2.attest.azure.net";
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "ohttp-server", about = "Serve oblivious HTTP requests.")]
+#[derive(Debug, Parser)]
+#[command(name = "ohttp-server", about = "Serve oblivious HTTP requests.")]
 struct Args {
     /// The address to bind to.
-    #[structopt(default_value = "127.0.0.1:9443")]
+    #[arg(default_value = "127.0.0.1:9443")]
     address: SocketAddr,
 
     /// When creating message/bhttp, use the indeterminate-length form.
-    #[structopt(long, short = "n", alias = "indefinite")]
+    #[arg(long, short = 'n', alias = "indefinite")]
     indeterminate: bool,
 
-    /// Certificate to use for serving.
-    #[structopt(long, short = "c", default_value = concat!(env!("CARGO_MANIFEST_DIR"), "/server.crt"))]
-    certificate: PathBuf,
-
-    /// Key for the certificate to use for serving.
-    #[structopt(long, short = "k", default_value = concat!(env!("CARGO_MANIFEST_DIR"), "/server.key"))]
-    key: PathBuf,
-
     /// Target server
-    #[structopt(long, short = "t", default_value = "http://127.0.0.1:8000")]
+    #[arg(long, short = 't', default_value = "http://127.0.0.1:8000")]
     target: Url,
 
     /// Obtain key configuration from a KMS after attestation
-    #[structopt(long, short = "a")]
+    #[arg(long, short = 'a')]
     attest: bool,
 
     /// MAA endpoint
-    #[structopt(long, short = "m")]
+    #[arg(long, short = 'm')]
     maa_url: Option<String>,
 
     /// KMS endpoint
-    #[structopt(long, short = "s")]
+    #[arg(long, short = 's')]
     kms_url: Option<String>,
 }
 
@@ -364,7 +356,7 @@ async fn import_config(kms: &str, maa: &str) -> Res<KeyConfig> {
 
 #[tokio::main]
 async fn main() -> Res<()> {
-    let args = Args::from_args();
+    let args = Args::parse();
     ::ohttp::init();
     env_logger::try_init().unwrap();
 
@@ -408,9 +400,6 @@ async fn main() -> Res<()> {
     let routes = score.or(discover);
 
     warp::serve(routes)
-        .tls()
-        .cert_path(args.certificate)
-        .key_path(args.key)
         .run(args.address)
         .await;
 


### PR DESCRIPTION
This PR adds support in the ohttp-client for curl like flags -F and -H for specifying headers and form fields in the encapsulated request. It also adds a -O flag for specifying headers for the outer request. 

Other changes
- Switch to use HTTP instead HTTPS
- clap instead of structopt for parsing command line options
