### PR TITLE
Add thread id and spans to correlate all the events coming from one score.

### DIFF
--- a/ohttp-server/Cargo.toml
+++ b/ohttp-server/Cargo.toml
@@ -31,6 +31,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3.18", features = ["default", "json", "env-filter"] }
 thiserror = "1"
 backtrace = "0.3"
+uuid = { version = "1.0", features = ["v4"] }
 
 [dependencies.bhttp]
 path= "../bhttp"

--- a/ohttp-server/src/main.rs
+++ b/ohttp-server/src/main.rs
@@ -35,8 +35,9 @@ use hpke::Deserializable;
 use serde::{Deserialize, Serialize};
 
 use err::ServerError;
-use tracing::{error, info, trace};
-use tracing_subscriber::{EnvFilter, FmtSubscriber};
+use tracing::{error, info, info_span, trace, Instrument};
+use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter, FmtSubscriber};
+use uuid::Uuid;
 
 use backtrace::Backtrace;
 
@@ -397,110 +398,115 @@ async fn score(
     body: warp::hyper::body::Bytes,
     args: Arc<Args>,
 ) -> Result<impl warp::Reply, std::convert::Infallible> {
-    let target = args.target.clone();
-    info!("Received encapsulated score request for target {}", target);
+    let span = info_span!("x-ms-request-id", guid = %Uuid::new_v4());
+    async move {
+        let target = args.target.clone();
+        info!("Received encapsulated score request for target {}", target);
 
-    info!("Request headers length = {}", headers.len());
-    let return_token = headers.contains_key("x-attestation-token");
+        info!("Request headers length = {}", headers.len());
+        let return_token = headers.contains_key("x-attestation-token");
 
-    // The KID is normally the first byte of the request
-    let kid = match body.first().copied() {
-        None => {
-            return Ok(warp::http::Response::builder()
-                .status(500)
-                .body(Body::from(&b"No key found in request."[..])))
-        }
-        Some(kid) => kid,
-    };
-    let maa_url = args.maa_url.clone().unwrap_or(DEFAULT_MAA_URL.to_string());
-    let kms_url = args.kms_url.clone().unwrap_or(DEFAULT_KMS_URL.to_string());
-    let (ohttp, token) = match load_config(&maa_url, &kms_url, kid).await {
-        Err(e) => {
-            error_with_backtrace!(e);
-            return Ok(warp::http::Response::builder().status(500).body(Body::from(
-                &b"Failed to get or load OHTTP configuration."[..],
-            )));
-        }
-        Ok((config, token)) => match OhttpServer::new(config) {
-            Ok(server) => (server, token),
+        // The KID is normally the first byte of the request
+        let kid = match body.first().copied() {
+            None => {
+                return Ok(warp::http::Response::builder()
+                    .status(500)
+                    .body(Body::from(&b"No key found in request."[..])))
+            }
+            Some(kid) => kid,
+        };
+        let maa_url = args.maa_url.clone().unwrap_or(DEFAULT_MAA_URL.to_string());
+        let kms_url = args.kms_url.clone().unwrap_or(DEFAULT_KMS_URL.to_string());
+        let (ohttp, token) = match load_config(&maa_url, &kms_url, kid).await {
             Err(e) => {
                 error_with_backtrace!(e);
                 return Ok(warp::http::Response::builder().status(500).body(Body::from(
                     &b"Failed to get or load OHTTP configuration."[..],
                 )));
             }
-        },
-    };
-
-    let inject_request_headers = args.inject_request_headers.clone();
-    info!(
-        "Request inject headers length = {}",
-        inject_request_headers.len()
-    );
-    for key in &inject_request_headers {
-        info!("    {}", key);
-    }
-
-    let inject_headers = compute_injected_headers(&headers, inject_request_headers);
-    info!("Injected headers length = {}", inject_headers.len());
-    for (key, value) in &inject_headers {
-        info!("    {}: {}", key, value.to_str().unwrap());
-    }
-
-    let mode = args.mode();
-    let (response, server_response) =
-        match generate_reply(&ohttp, inject_headers, &body[..], target, mode).await {
-            Ok(s) => s,
-            Err(e) => {
-                error_with_backtrace!(e);
-                if let Ok(oe) = e.downcast::<::ohttp::Error>() {
-                    return Ok(warp::http::Response::builder()
-                        .status(422)
-                        .body(Body::from(format!("Error: {oe:?}"))));
+            Ok((config, token)) => match OhttpServer::new(config) {
+                Ok(server) => (server, token),
+                Err(e) => {
+                    error_with_backtrace!(e);
+                    return Ok(warp::http::Response::builder().status(500).body(Body::from(
+                        &b"Failed to get or load OHTTP configuration."[..],
+                    )));
                 }
-
-                return Ok(warp::http::Response::builder()
-                    .status(400)
-                    .body(Body::from(&b"Request error"[..])));
-            }
+            },
         };
 
-    let mut builder =
-        warp::http::Response::builder().header("Content-Type", "message/ohttp-chunked-res");
-
-    // Add HTTP header with MAA token, for client auditing.
-    if return_token {
-        builder = builder.header(
-            HeaderName::from_static("x-attestation-token"),
-            token.clone(),
+        let inject_request_headers = args.inject_request_headers.clone();
+        info!(
+            "Request inject headers length = {}",
+            inject_request_headers.len()
         );
-    }
+        for key in &inject_request_headers {
+            info!("    {}", key);
+        }
 
-    // Move headers from the inner response into the outer response
-    info!("Response headers:");
-    for (key, value) in response.headers() {
-        if !FILTERED_RESPONSE_HEADERS
-            .iter()
-            .any(|h| h.eq_ignore_ascii_case(key.as_str()))
-        {
-            info!(
-                "    {}: {}",
-                key,
-                std::str::from_utf8(value.as_bytes()).unwrap()
+        let inject_headers = compute_injected_headers(&headers, inject_request_headers);
+        info!("Injected headers length = {}", inject_headers.len());
+        for (key, value) in &inject_headers {
+            info!("    {}: {}", key, value.to_str().unwrap());
+        }
+
+        let mode = args.mode();
+        let (response, server_response) =
+            match generate_reply(&ohttp, inject_headers, &body[..], target, mode).await {
+                Ok(s) => s,
+                Err(e) => {
+                    error_with_backtrace!(e);
+                    if let Ok(oe) = e.downcast::<::ohttp::Error>() {
+                        return Ok(warp::http::Response::builder()
+                            .status(422)
+                            .body(Body::from(format!("Error: {oe:?}"))));
+                    }
+
+                    return Ok(warp::http::Response::builder()
+                        .status(400)
+                        .body(Body::from(&b"Request error"[..])));
+                }
+            };
+
+        let mut builder =
+            warp::http::Response::builder().header("Content-Type", "message/ohttp-chunked-res");
+
+        // Add HTTP header with MAA token, for client auditing.
+        if return_token {
+            builder = builder.header(
+                HeaderName::from_static("x-attestation-token"),
+                token.clone(),
             );
-            builder = builder.header(key.as_str(), value.as_bytes());
         }
+
+        // Move headers from the inner response into the outer response
+        info!("Response headers:");
+        for (key, value) in response.headers() {
+            if !FILTERED_RESPONSE_HEADERS
+                .iter()
+                .any(|h| h.eq_ignore_ascii_case(key.as_str()))
+            {
+                info!(
+                    "    {}: {}",
+                    key,
+                    std::str::from_utf8(value.as_bytes()).unwrap()
+                );
+                builder = builder.header(key.as_str(), value.as_bytes());
+            }
+        }
+
+        let stream = Box::pin(unfold(response, |mut response| async move {
+            match response.chunk().await {
+                Ok(Some(chunk)) => Some((Ok::<Vec<u8>, ohttp::Error>(chunk.to_vec()), response)),
+                _ => None,
+            }
+        }));
+
+        let stream = server_response.encapsulate_stream(stream);
+        Ok(builder.body(Body::wrap_stream(stream)))
     }
-
-    let stream = Box::pin(unfold(response, |mut response| async move {
-        match response.chunk().await {
-            Ok(Some(chunk)) => Some((Ok::<Vec<u8>, ohttp::Error>(chunk.to_vec()), response)),
-            _ => None,
-        }
-    }));
-
-    let stream = server_response.encapsulate_stream(stream);
-    Ok(builder.body(Body::wrap_stream(stream)))
+    .instrument(span)
+    .await
 }
 
 async fn discover(args: Arc<Args>) -> Result<impl warp::Reply, std::convert::Infallible> {
@@ -547,6 +553,8 @@ async fn main() -> Res<()> {
         .with_env_filter(EnvFilter::from_default_env())
         .with_file(true)
         .with_line_number(true)
+        .with_thread_ids(true)
+        .with_span_events(FmtSpan::FULL)
         .json()
         .finish();
 


### PR DESCRIPTION
All the logs associated with a single client request will have a unique GUID x-ms-request-id
 
  14 {"timestamp":"2024-10-24T03:11:04.083005Z","level":"INFO","fields":{"message":"new"},"target":"ohttp_server","filename":"ohttp-server/src/main.rs","line_number":401,"span":{"guid":"1c63e97d-f03e-416b-bdb7-5942ed89aa34","name":"x-ms-request-id"},"spans":[],"threadId":"ThreadId(40)"}
15 {"timestamp":"2024-10-24T03:11:04.083104Z","level":"INFO","fields":{"message":"enter"},"target":"ohttp_server","filename":"ohttp-server/src/main.rs","line_number":401,"span":{"guid":"1c63e97d-f03e-416b-bdb7-5942ed89aa34","name":"x-ms-request-id"},"spans":[{"guid":"1c63e97d-f03e-416b-bdb7-5942ed89aa34","name":"x-ms-request-id"}],"threadId":"ThreadId(40)"}
16 {"timestamp":"2024-10-24T03:11:04.083164Z","level":"INFO","fields":{"message":"Received encapsulated score request for target http://127.0.0.1:5001/"},"target":"ohttp_server","filename":"ohttp-server/src/main.rs","line_number":404,"span":{"guid":"1c63e97d-f03e-416b-bdb7-5942ed89aa34","name":"x-ms-request-id"},"spans":[{"guid":"1c63e97d-f03e-416b-bdb7-5942ed89aa34","name":"x-ms-request-id"}],"threadId":"ThreadId(40)"}
17 {"timestamp":"2024-10-24T03:11:04.083217Z","level":"INFO","fields":{"message":"Request headers length = 6"},"target":"ohttp_server","filename":"ohttp-server/src/main.rs","line_number":406,"span":{"guid":"1c63e97d-f03e-416b-bdb7-5942ed89aa34","name":"x-ms-request-id"},"spans":[{"guid":"1c63e97d-f03e-416b-bdb7-5942ed89aa34","name":"x-ms-request-id"}],"threadId":"ThreadId(40)"}
18 {"timestamp":"2024-10-24T03:11:04.083436Z","level":"INFO","fields":{"message":"Fetching MAA token from https://maanosecureboottestyfu.eus.attest.azure.net"},"target":"ohttp_server","filename":"ohttp-server/src/main.rs","line_number":210,"span":{"guid":"1c63e97d-f03e-416b-bdb7-5942ed89aa34","name":"x-ms-request-id"},"spans":[{"guid":"1c63e97d-f03e-416b-bdb7-5942ed89aa34","name":"x-ms-request-id"}],"threadId":"ThreadId(40)"}
19 {"timestamp":"2024-10-24T03:11:04.422488Z","level":"INFO","fields":{"message":"Sending SKR request to https://accconfinferencedebug.confidential-ledger.azure.com/app/key?kid=9"},"target":"ohttp_server","filename":"ohttp-server/src/main.rs","line_number":231,"span":{"guid":"1c63e97d-f03e-416b-bdb7-5942ed89aa34","name":"x-ms-request-id"},"spans":[{"guid":"1c63e97d-f03e-416b-bdb7-5942ed89aa34","name":"x-ms-request-id"}],"threadId":"ThreadId(40)"}

