### PR TITLE
client docker changes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -105,7 +105,7 @@ jobs:
         run: | 
           ./scripts/service_wait.sh 127.0.0.1:3000
           ./scripts/service_wait.sh 127.0.0.1:9443
-          make run-client-container-local
+          make run-client-container
 
       - name: Stop containers
         run: |

--- a/Makefile
+++ b/Makefile
@@ -109,12 +109,12 @@ run-client-kms-aoai: service-cert
 	--kms-cert ./service_cert.pem \
 	-O 'openai-internal-enableasrsupport:true' -H 'openai-internal-enableasrsupport:true'
 
-run-client-kms-aoai: service-cert 
+run-client-kms-aoai-token: service-cert 
 	RUST_BACKTRACE=1 RUST_LOG=info cargo run --bin ohttp-client -- $(SCORING_ENDPOINT) \
 	--target-path ${TARGET_PATH} -F "file=@${INPUT}" -F "response_format=json" -F "language=en" \
 	--kms-cert ./service_cert.pem \
 	-H 'openai-internal-enableasrsupport:true' -O 'openai-internal-enableasrsupport:true' \
-	-O 'azureml-model-deployment:$(DEPLOYMENT)' -T ${TOKEN}
+	-O 'azureml-model-deployment:$(DEPLOYMENT)' -O 'authorization: Bearer ${TOKEN}
 
 # Containerized client deployments
 

--- a/Makefile
+++ b/Makefile
@@ -105,15 +105,15 @@ run-client-kms: service-cert
 
 run-client-kms-aoai: service-cert 
 	RUST_BACKTRACE=1 RUST_LOG=info cargo run --bin ohttp-client -- $(SCORING_ENDPOINT)\
-  --target-path ${TARGET_PATH} -F "file=@${INPUT}" \
-  --kms-cert ./service_cert.pem \
-  -O 'openai-internal-enableasrsupport:true' -H 'openai-internal-enableasrsupport:true'
+	--target-path ${TARGET_PATH} -F "file=@${INPUT}" \
+	--kms-cert ./service_cert.pem \
+	-O 'openai-internal-enableasrsupport:true' -H 'openai-internal-enableasrsupport:true'
 
 run-client-kms-aoai: service-cert 
 	RUST_BACKTRACE=1 RUST_LOG=info cargo run --bin ohttp-client -- $(SCORING_ENDPOINT) \
-  --target-path ${TARGET_PATH} -F "file=@${INPUT}" -F "response_format=json" -F "language=en" \
-  --kms-cert ./service_cert.pem \
-  -H 'openai-internal-enableasrsupport:true' -O 'openai-internal-enableasrsupport:true' \
+	--target-path ${TARGET_PATH} -F "file=@${INPUT}" -F "response_format=json" -F "language=en" \
+	--kms-cert ./service_cert.pem \
+	-H 'openai-internal-enableasrsupport:true' -O 'openai-internal-enableasrsupport:true' \
 	-O 'azureml-model-deployment:$(DEPLOYMENT)' -T ${TOKEN}
 
 # Containerized client deployments
@@ -121,7 +121,7 @@ run-client-kms-aoai: service-cert
 run-client-container:
 	docker run --privileged --net=host --volume ${INPUT}:${MOUNTED_INPUT} ohttp-client \
 	$(SCORING_ENDPOINT) --target-path ${TARGET_PATH} -F "file=@${MOUNTED_INPUT}" \
-  --config `curl -s http://localhost:9443/discover`
+	--config `curl -s http://localhost:9443/discover`
 
 run-client-container-kms: service-cert
 	docker run --volume ${INPUT}:${MOUNTED_INPUT} \

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ run-client-kms-aoai-token: service-cert
 	--target-path ${TARGET_PATH} -F "file=@${INPUT}" -F "response_format=json" -F "language=en" \
 	--kms-cert ./service_cert.pem \
 	-H 'openai-internal-enableasrsupport:true' -O 'openai-internal-enableasrsupport:true' \
-	-O 'azureml-model-deployment:$(DEPLOYMENT)' -O 'authorization: Bearer ${TOKEN}
+	-O 'azureml-model-deployment:$(DEPLOYMENT)' -O 'authorization: Bearer ${TOKEN}'
 
 # Containerized client deployments
 

--- a/Makefile
+++ b/Makefile
@@ -20,28 +20,29 @@ else
 	echo "Unknown model"
 endif
 	
-export INPUT ?= ./examples/audio.mp3
+export INPUT ?= ${PWD}/examples/audio.mp3
+export MOUNTED_INPUT ?= /examples/audio.mp3
 export INJECT_HEADERS ?= openai-internal-enableasrsupport
 export DETACHED ?= -d
 
 # Build commands
 
-build-server-local:
+build-server:
 	cargo build --bin ohttp-server
 
-build-client-local:
+build-client:
 	cargo build --bin ohttp-client
 
-build-whisper:
+build-whisper-container:
 	docker build -f docker/whisper/Dockerfile -t whisper-api ./docker/whisper
 
-build-server:
+build-server-container:
 	docker build -f docker/server/Dockerfile -t ohttp-server .
 
-build-client:
+build-client-container:
 	docker build -f docker/client/Dockerfile -t ohttp-client .
 
-build: build-server build-client build-whisper
+build: build-server-container build-client-container build-whisper-container
 
 format-checks:
 	cargo fmt --all -- --check --config imports_granularity=Crate
@@ -49,7 +50,7 @@ format-checks:
 
 # Local server deployments
 
-run-server-attest:
+run-server-kms:
 	cargo run --bin ohttp-server -- --target ${TARGET} \
 		--maa-url ${MAA} --kms-url ${KMS}
 
@@ -92,7 +93,7 @@ verify-quote:
 
 # Local client deployments
 
-run-client-local:
+run-client:
 	RUST_BACKTRACE=1 RUST_LOG=info cargo run --bin ohttp-client -- $(SCORING_ENDPOINT)\
   --target-path ${TARGET_PATH} -F "file=@${INPUT}" \
   --config `curl -s http://localhost:9443/discover` 
@@ -102,7 +103,7 @@ run-client-kms: service-cert
   --target-path ${TARGET_PATH} -F "file=@${INPUT}" \
   --kms-cert ./service_cert.pem 
 
-run-client-kms-aoai-local: service-cert 
+run-client-kms-aoai: service-cert 
 	RUST_BACKTRACE=1 RUST_LOG=info cargo run --bin ohttp-client -- $(SCORING_ENDPOINT)\
   --target-path ${TARGET_PATH} -F "file=@${INPUT}" \
   --kms-cert ./service_cert.pem \
@@ -117,16 +118,16 @@ run-client-kms-aoai: service-cert
 
 # Containerized client deployments
 
-run-client-container-local:
-	docker run --privileged --net=host -e SCORING_ENDPOINT=${SCORING_ENDPOINT} \
-	-e TARGET_PATH=${TARGET_PATH} -e INPUT=${INPUT} ohttp-client
-
 run-client-container:
-	docker run --privileged --net=host -e SCORING_ENDPOINT=${SCORING_ENDPOINT} \
-	-e TARGET_PATH=${TARGET_PATH} -e KMS_URL=${KMS} \
-	-e INPUT=${INPUT} ohttp-client
+	docker run --privileged --net=host --volume ${INPUT}:${MOUNTED_INPUT} ohttp-client \
+	$(SCORING_ENDPOINT) --target-path ${TARGET_PATH} -F "file=@${MOUNTED_INPUT}" \
+  --config `curl -s http://localhost:9443/discover`
+
+run-client-container-kms: service-cert
+	docker run --privileged --net=host --volume ${INPUT}:${MOUNTED_INPUT} \
+	--volume ./service_cert.pem:/tmp/service_cert.pem ohttp-client \
+	${SCORING_ENDPOINT} --target-path ${TARGET_PATH} -F "file=@${MOUNTED_INPUT}" \
+  --maa-url=${MAA} --kms-url=${KMS} --kms-cert /tmp/service_cert.pem 
 
 run-client-container-it:
-	docker run -it --privileged --net=host -e SCORING_ENDPOINT=${SCORING_ENDPOINT} \
-	-e TARGET_PATH=${TARGET_PATH} -e KMS_URL=${KMS} \
-	-e INPUT=${INPUT} ohttp-client bash
+	docker run -it --privileged --net=host -it --entrypoint=/bin/bash ohttp-client

--- a/Makefile
+++ b/Makefile
@@ -124,10 +124,10 @@ run-client-container:
   --config `curl -s http://localhost:9443/discover`
 
 run-client-container-kms: service-cert
-	docker run --privileged --net=host --volume ${INPUT}:${MOUNTED_INPUT} \
+	docker run --volume ${INPUT}:${MOUNTED_INPUT} \
 	--volume ./service_cert.pem:/tmp/service_cert.pem ohttp-client \
 	${SCORING_ENDPOINT} --target-path ${TARGET_PATH} -F "file=@${MOUNTED_INPUT}" \
-  --maa-url=${MAA} --kms-url=${KMS} --kms-cert /tmp/service_cert.pem 
+	--maa-url=${MAA} --kms-url=${KMS} --kms-cert /tmp/service_cert.pem 
 
 run-client-container-it:
 	docker run -it --privileged --net=host -it --entrypoint=/bin/bash ohttp-client

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -12,8 +12,7 @@ RUN cargo install --path ohttp-client --debug
 
 FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y ca-certificates openssl curl jq && rm -rf /var/lib/apt/lists/*
-COPY ./ohttp-server/ca.sh /usr/local/bin
-COPY ./examples ./examples
 COPY --from=builder /usr/local/cargo/bin/ohttp-client /usr/local/bin/ohttp-client
-COPY --chmod=755 ./docker/client/run.sh .
-CMD ["./run.sh"]
+ENV RUST_BACKTRACE=1
+ENV RUST_LOG=info
+ENTRYPOINT [ "/usr/local/bin/ohttp-client" ]

--- a/ohttp-client/src/main.rs
+++ b/ohttp-client/src/main.rs
@@ -2,7 +2,7 @@ use bhttp::{Message, Mode};
 use clap::Parser;
 use futures_util::{stream::unfold, StreamExt};
 use ohttp::ClientRequest;
-use reqwest::{header::AUTHORIZATION, Client};
+use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::{
     fs::{self, File},
@@ -136,10 +136,6 @@ struct Args {
     /// List of headers in the outer request
     #[arg(long, short = 'O')]
     outer_headers: Option<Vec<String>>,
-
-    /// Token for the outer request
-    #[arg(long, short = 'T')]
-    token: Option<String>,
 }
 
 /// Writes the request line for an HTTP POST request to the provided buffer.
@@ -380,17 +376,13 @@ async fn create_request_from_kms_config(
 async fn post_request(
     url: &String,
     outer_headers: &Option<Vec<String>>,
-    token: &Option<String>,
     enc_request: Vec<u8>,
 ) -> Res<reqwest::Response> {
     let client = reqwest::ClientBuilder::new().build()?;
 
-    let tokenstr = token.as_ref().map_or("None", |s| s.as_str());
-
     let mut builder = client
         .post(url)
-        .header("content-type", "message/ohttp-chunked-req")
-        .header(AUTHORIZATION, format!("Bearer {tokenstr}"));
+        .header("content-type", "message/ohttp-chunked-req");
 
     // Add outer headers
     trace!("Outer request headers:");
@@ -519,14 +511,13 @@ async fn main() -> Res<()> {
     );
 
     // Post the encapsulated ohttp request buffer to args.url
-    let response =
-        match post_request(&args.url, &args.outer_headers, &args.token, enc_request).await {
-            Ok(response) => response,
-            Err(e) => {
-                error_with_backtrace!(e);
-                return Err(e);
-            }
-        };
+    let response = match post_request(&args.url, &args.outer_headers, enc_request).await {
+        Ok(response) => response,
+        Err(e) => {
+            error_with_backtrace!(e);
+            return Err(e);
+        }
+    };
     trace!("Posted the OHTTP request to {}", args.url);
 
     // decapsulate and output the http response


### PR DESCRIPTION
This PR allows clients to use the client docker container with the same command lime arguments as the ohttp-client. So users can run the ohttp-client as follows.

```
docker run ohttp-client <volume_mount_for_kms_cert> <volume_mount_for_audio_file> <ohttp-client command line>
```

Through the command line, the user can pass api keys or bearer tokens required for authentication. No special handling for tokens is required. 