### PR TITLE
set target path using enginetarget

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: ["main"]
     paths-ignore: ["*.md", "LICENSE-*"]
+  workflow_dispatch:
+  
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/ohttp-client/README.md
+++ b/ohttp-client/README.md
@@ -13,7 +13,6 @@ You can use pre-built attested OHTTP container images to send an inferencing req
 Set the inferencing endpoint and accessk key as follows.
 ```
 export TARGET_URI=<URL for your endpoint>
-export TARGET_PATH=/v1/engines/whisper/audio/translations
 export KEY=<key for accessing the endpoint>
 ```
 
@@ -21,8 +20,7 @@ Run inferencing using a pre-packaged audio file.
 ```
 export KMS_URL=https://accconfinferencedebug.confidential-ledger.azure.com
 docker run -e KMS_URL=${KMS_URL} mcr.microsoft.com/attested-ohttp-client:latest \
-  ${TARGET_URI} --target-path ${TARGET_PATH} -F "file=@/examples/audio.mp3" \
-  -O "api-key: ${KEY}" -F "response_format=json"
+  ${TARGET_URI} -F "file=@/examples/audio.mp3" -O "api-key: ${KEY}" -F "response_format=json"
 ```
 
 Run inferencing using your own audio file by mounting the file into the container.
@@ -32,8 +30,7 @@ export INPUT_PATH=<path to your input file>
 export MOUNTED_PATH=/examples/audio.mp3
 docker run -e KMS_URL=${KMS_URL} --volume ${INPUT_PATH}:${MOUNTED_PATH} \
   mcr.microsoft.com/attested-ohttp-client:latest \
-  ${TARGET_URI} --target-path ${TARGET_PATH} -F "file=@${MOUNTED_INPUT}" \
-  -O "api-key ${KEY}" -F "response_format=json"
+  ${TARGET_URI} -F "file=@${MOUNTED_INPUT}" -O "api-key ${KEY}" -F "response_format=json"
 ```
 
 ## Building your own container image

--- a/ohttp-client/src/main.rs
+++ b/ohttp-client/src/main.rs
@@ -95,7 +95,7 @@ struct Args {
     url: String,
 
     /// Target path of the oblivious resource
-    #[arg(long, short = 'p')]
+    #[arg(long, short = 'p', default_value = "/")]
     target_path: String,
 
     /// key configuration


### PR DESCRIPTION
This PR introduces changes to the OHTTP gateway to set the target path using the ```enginetarget``` header specified in the outer request. The client specified path is used only if there is no such header. 