### PR TITLE
refactor OHTTP library dependency

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,6 @@ on:
   
 env:
   CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
   
 jobs:
   check:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: ["main"]
     paths-ignore: ["*.md", "LICENSE-*"]
+  workflow_dispatch:
+  
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/Makefile
+++ b/Makefile
@@ -94,30 +94,30 @@ verify-quote:
 # Local client deployments
 
 run-client:
-	RUST_BACKTRACE=1 RUST_LOG=info cargo run --bin ohttp-client -- $(SCORING_ENDPOINT)\
+	RUST_LOG=info cargo run --bin ohttp-client -- $(SCORING_ENDPOINT) \
   --target-path ${TARGET_PATH} -F "file=@${INPUT}" \
   --config `curl -s http://localhost:9443/discover` 
 
 run-client-kms: service-cert 
-	RUST_BACKTRACE=1 RUST_LOG=info cargo run --bin ohttp-client -- $(SCORING_ENDPOINT)\
+	RUST_LOG=info cargo run --bin ohttp-client -- $(SCORING_ENDPOINT) \
   --target-path ${TARGET_PATH} -F "file=@${INPUT}" \
   --kms-url ${KMS} --kms-cert ./service_cert.pem 
 
 run-client-kms-aoai: service-cert 
-	RUST_BACKTRACE=1 RUST_LOG=info cargo run --bin ohttp-client -- $(SCORING_ENDPOINT)\
+	RUST_LOG=info cargo run --bin ohttp-client -- $(SCORING_ENDPOINT) \
 	--target-path ${TARGET_PATH} -F "file=@${INPUT}" \
 	--kms-url ${KMS} --kms-cert ./service_cert.pem \
 	-O 'openai-internal-enableasrsupport:true' -H 'openai-internal-enableasrsupport:true'
 
 run-client-kms-aoai-token: service-cert 
-	RUST_BACKTRACE=1 RUST_LOG=info cargo run --bin ohttp-client -- $(SCORING_ENDPOINT) \
+	RUST_LOG=info cargo run --bin ohttp-client -- $(SCORING_ENDPOINT) \
 	--target-path ${TARGET_PATH} -F "file=@${INPUT}" -F "response_format=json" -F "language=en" \
 	--kms-url ${KMS} --kms-cert ./service_cert.pem \
 	-H 'openai-internal-enableasrsupport:true' -O 'openai-internal-enableasrsupport:true' \
 	-O 'azureml-model-deployment:$(DEPLOYMENT)' -O 'authorization: Bearer ${TOKEN}'
 
 run-client-kms-aoai-apim-token: service-cert
-	RUST_BACKTRACE=1 RUST_LOG=info cargo run --bin ohttp-client -- ${APIM_ENDPOINT} \
+	RUST_LOG=info cargo run --bin ohttp-client -- ${APIM_ENDPOINT} \
 	--target-path ${TARGET_PATH} -F "file=@${INPUT}" -F "response_format=json" \
 	--kms-url ${KMS} --kms-cert ./service_cert.pem -O 'api-key: ${API_KEY}'
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ else ifeq ($(MODEL), whisper_aoai_local)
 	SCORING_ENDPOINT ?= 'http://localhost:9443/score'
 else ifeq ($(MODEL), whisper_aoai)
 	TARGET ?= http://127.0.0.1:5002
-	TARGET_PATH ?= '/v1/engines/whisper/audio/transcriptions'
+	TARGET_PATH ?= '/v1/engines/whisper/audio/translations'
 	DEPLOYMENT ?= 'arthig-deploy20'
 	SCORING_ENDPOINT ?= 'https://arthig-ep.eastus2.inference.ml.azure.com/score'
 else
@@ -101,33 +101,40 @@ run-client:
 run-client-kms: service-cert 
 	RUST_BACKTRACE=1 RUST_LOG=info cargo run --bin ohttp-client -- $(SCORING_ENDPOINT)\
   --target-path ${TARGET_PATH} -F "file=@${INPUT}" \
-  --kms-cert ./service_cert.pem 
+  --kms-url ${KMS} --kms-cert ./service_cert.pem 
 
 run-client-kms-aoai: service-cert 
 	RUST_BACKTRACE=1 RUST_LOG=info cargo run --bin ohttp-client -- $(SCORING_ENDPOINT)\
 	--target-path ${TARGET_PATH} -F "file=@${INPUT}" \
-	--kms-cert ./service_cert.pem \
+	--kms-url ${KMS} --kms-cert ./service_cert.pem \
 	-O 'openai-internal-enableasrsupport:true' -H 'openai-internal-enableasrsupport:true'
 
 run-client-kms-aoai-token: service-cert 
 	RUST_BACKTRACE=1 RUST_LOG=info cargo run --bin ohttp-client -- $(SCORING_ENDPOINT) \
 	--target-path ${TARGET_PATH} -F "file=@${INPUT}" -F "response_format=json" -F "language=en" \
-	--kms-cert ./service_cert.pem \
+	--kms-url ${KMS} --kms-cert ./service_cert.pem \
 	-H 'openai-internal-enableasrsupport:true' -O 'openai-internal-enableasrsupport:true' \
 	-O 'azureml-model-deployment:$(DEPLOYMENT)' -O 'authorization: Bearer ${TOKEN}'
+
+run-client-kms-aoai-apim-token: service-cert
+	RUST_BACKTRACE=1 RUST_LOG=info cargo run --bin ohttp-client -- ${APIM_ENDPOINT} \
+	--target-path ${TARGET_PATH} -F "file=@${INPUT}" -F "response_format=json" \
+	--kms-url ${KMS} --kms-cert ./service_cert.pem -O 'api-key: ${API_KEY}'
 
 # Containerized client deployments
 
 run-client-container:
-	docker run --privileged --net=host --volume ${INPUT}:${MOUNTED_INPUT} ohttp-client \
-	$(SCORING_ENDPOINT) --target-path ${TARGET_PATH} -F "file=@${MOUNTED_INPUT}" \
-	--config `curl -s http://localhost:9443/discover`
+	docker run --net=host --volume ${INPUT}:${MOUNTED_INPUT} \
+	ohttp-client $(SCORING_ENDPOINT) -F "file=@${MOUNTED_INPUT}" --target-path ${TARGET_PATH}
 
-run-client-container-kms: service-cert
-	docker run --volume ${INPUT}:${MOUNTED_INPUT} \
-	--volume ./service_cert.pem:/tmp/service_cert.pem ohttp-client \
-	${SCORING_ENDPOINT} --target-path ${TARGET_PATH} -F "file=@${MOUNTED_INPUT}" \
-	--maa-url=${MAA} --kms-url=${KMS} --kms-cert /tmp/service_cert.pem 
+run-client-container-kms:
+	docker run --net=host --volume ${INPUT}:${MOUNTED_INPUT} -e KMS_URL=${KMS} \
+	ohttp-client ${SCORING_ENDPOINT} -F "file=@${MOUNTED_INPUT}" --target-path ${TARGET_PATH}
 
 run-client-container-it:
 	docker run -it --privileged --net=host -it --entrypoint=/bin/bash ohttp-client
+
+run-client-container-aoai:
+	docker run --volume ${INPUT}:${MOUNTED_INPUT} -e KMS_URL=${KMS} \
+	ohttp-client ${SCORING_ENDPOINT} -F "file=@${MOUNTED_INPUT}" --target-path ${TARGET_PATH} \
+	-O "api-key: ${API_KEY}" -F "response_format=json"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ the server sees your IP address.
 
 The repo supports development using GitHub Codespaces and devcontainers. 
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=707634300&skip_quickstart=true&machine=premiumLinux&geo=EuropeWest)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/kapilvgit/ohttp)
 
 ## Build and Test
 

--- a/bhttp/Cargo.toml
+++ b/bhttp/Cargo.toml
@@ -22,7 +22,6 @@ stream = []
 thiserror = "1"
 url = {version = "2", optional = true}
 tracing = "0.1"
-backtrace = "0.3"
 
 [dev-dependencies]
 hex = "0.4"

--- a/cgpuvm-attest/Cargo.toml
+++ b/cgpuvm-attest/Cargo.toml
@@ -14,7 +14,6 @@ default = []
 libc = "0.2.0"
 tracing = "0.1"
 thiserror = "1"
-backtrace = "0.3"
 
 [dependencies.ohttp]
 path= "../ohttp"

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -13,6 +13,9 @@ RUN cargo install --path ohttp-client --debug
 FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y ca-certificates openssl curl jq && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/ohttp-client /usr/local/bin/ohttp-client
+COPY ./examples/audio.mp3 ./examples/audio.mp3
+COPY ./examples/15m_gpt-has-entered-the-chat.mp3 ./examples/15m_gpt-has-entered-the-chat.mp3
+COPY --chmod=755 ./docker/client/run.sh .
 ENV RUST_BACKTRACE=1
 ENV RUST_LOG=info
-ENTRYPOINT [ "/usr/local/bin/ohttp-client" ]
+ENTRYPOINT [ "./run.sh" ]

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -16,6 +16,5 @@ COPY --from=builder /usr/local/cargo/bin/ohttp-client /usr/local/bin/ohttp-clien
 COPY ./examples/audio.mp3 ./examples/audio.mp3
 COPY ./examples/15m_gpt-has-entered-the-chat.mp3 ./examples/15m_gpt-has-entered-the-chat.mp3
 COPY --chmod=755 ./docker/client/run.sh .
-ENV RUST_BACKTRACE=1
 ENV RUST_LOG=info
 ENTRYPOINT [ "./run.sh" ]

--- a/docker/client/run.sh
+++ b/docker/client/run.sh
@@ -13,35 +13,18 @@ is_valid_url() {
     fi
 }
 
-if [[ -z ${SCORING_ENDPOINT} ]]; then
-  echo "No SCORING_ENDPOINT defined"
-  exit 1
-fi
-
-if [[ -z ${TARGET_PATH} ]]; then
-  echo "No TARGET_PATH defined"
-  exit 1
-fi
-
-if [[ -z ${INPUT} ]]; then
-  echo "No INPUT defined"
-  exit 1
-fi
-
-CMD="RUST_BACKTRACE=1 RUST_LOG=info /usr/local/bin/ohttp-client ${SCORING_ENDPOINT} --target-path ${TARGET_PATH} -F \"file=@${INPUT}\""
-
 if [[ -n ${KMS_URL} ]]; then 
   if is_valid_url $KMS_URL; then 
     # Obtain KMS service certificate
     curl -s -k ${KMS_URL}/node/network | jq -r .service_certificate > /tmp/service_cert.pem
-    CMD="$CMD --kms-url ${KMS_URL} --kms-cert /tmp/service_cert.pem"
+    ARGS="$ARGS --kms-url ${KMS_URL} --kms-cert /tmp/service_cert.pem"
   else 
     echo "Invalid KMS URL"
     exit 1
   fi
 else 
-  CMD="$CMD --config `curl -s http://localhost:9443/discover`"
+  ARGS="$ARGS --config `curl -s http://localhost:9443/discover`"
 fi
 
-echo "Running $CMD..."
-eval $CMD
+echo "Running /usr/local/bin/ohttp-client" "$@" ${ARGS}
+RUST_LOG=info /usr/local/bin/ohttp-client "$@" ${ARGS}

--- a/docker/server/run.sh
+++ b/docker/server/run.sh
@@ -18,9 +18,9 @@ if [[ -z ${TARGET} ]]; then
   exit 1
 fi
 
-CMD="RUST_BACKTRACE=1 RUST_LOG=info"
+CMD="RUST_LOG=info"
 if [[ -n ${TRACE} ]]; then
-  CMD="RUST_BACKTRACE=1 RUST_LOG=trace"
+  CMD="RUST_LOG=trace"
 fi
 
 if is_valid_url $TARGET; then 

--- a/ohttp-client/Cargo.toml
+++ b/ohttp-client/Cargo.toml
@@ -24,7 +24,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.18", features = ["default", "json", "env-filter"] }
-backtrace = "0.3"
 infer = "0.16.0"
 
 [dependencies.verifier]

--- a/ohttp-client/Cargo.toml
+++ b/ohttp-client/Cargo.toml
@@ -31,10 +31,12 @@ infer = "0.16.0"
 path= "../verifier"
 
 [dependencies.bhttp]
-path= "../bhttp"
+git = "https://github.com/kapilvgit/ohttp.git"
+branch = "kapilv/upstream"
 features = ["bhttp", "http"]
 
 [dependencies.ohttp]
-path= "../ohttp"
+git = "https://github.com/kapilvgit/ohttp.git"
+branch = "kapilv/upstream"
 features = ["client"]
 default-features = false

--- a/ohttp-client/README.md
+++ b/ohttp-client/README.md
@@ -41,7 +41,14 @@ The repo supports development using GitHub Codespaces and devcontainers. The rep
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/kapilvgit/ohttp)
 
-You can build the client containers as follows. 
+Alternatively, you can setup your own environment by installing dependencies.
+```
+sudo apt update
+sudo apt install -y curl build-essential jq
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Next, you can build the client containers as follows. 
 
 ```
 docker build -f docker/Dockerfile -t attested-ohttp-client .

--- a/ohttp-client/README.md
+++ b/ohttp-client/README.md
@@ -10,17 +10,17 @@ Azure AI confidential inferencing.
 ## Using pre-built image
 You can use pre-built attested OHTTP container images to send an inferencing request. 
 
-Set the inferencing endpoint and accessk key as follows.
+Set the inferencing endpoint and access key as follows.
 ```
 export TARGET_URI=<URL for your endpoint>
-export KEY=<key for accessing the endpoint>
+export API_KEY=<key for accessing the endpoint>
 ```
 
 Run inferencing using a pre-packaged audio file. 
 ```
 export KMS_URL=https://accconfinferencedebug.confidential-ledger.azure.com
 docker run -e KMS_URL=${KMS_URL} mcr.microsoft.com/attested-ohttp-client:latest \
-  ${TARGET_URI} -F "file=@/examples/audio.mp3" -O "api-key: ${KEY}" -F "response_format=json"
+  ${TARGET_URI} -F "file=@/examples/audio.mp3" -O "api-key: ${API_KEY}" -F "response_format=json"
 ```
 
 Run inferencing using your own audio file by mounting the file into the container.
@@ -30,17 +30,18 @@ export INPUT_PATH=<path to your input file>
 export MOUNTED_PATH=/examples/audio.mp3
 docker run -e KMS_URL=${KMS_URL} --volume ${INPUT_PATH}:${MOUNTED_PATH} \
   mcr.microsoft.com/attested-ohttp-client:latest \
-  ${TARGET_URI} -F "file=@${MOUNTED_INPUT}" -O "api-key ${KEY}" -F "response_format=json"
+  ${TARGET_URI} -F "file=@${MOUNTED_INPUT}" -O "api-key ${API_KEY}" -F "response_format=json"
 ```
 
 ## Building your own container image
 
-You can build you own container image using code in this repository. First, clone the repository. 
-```
-git clone https://github.com/microsoft/attested-ohttp-client
-```
+### Development Environment
 
-Next, build the docker image. 
+The repo supports development using GitHub Codespaces and devcontainers. The repository includes a devcontainer configuration that installs all dependencies. 
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/kapilvgit/ohttp)
+
+You can build the client containers as follows. 
 
 ```
 docker build -f docker/Dockerfile -t attested-ohttp-client .

--- a/ohttp-client/README.md
+++ b/ohttp-client/README.md
@@ -13,7 +13,6 @@ You can use pre-built attested OHTTP container images to send an inferencing req
 Set the inferencing endpoint and accessk key as follows.
 ```
 export TARGET_URI=<URL for your endpoint>
-export TARGET_PATH=/v1/engines/whisper/audio/translations
 export KEY=<key for accessing the endpoint>
 ```
 
@@ -21,8 +20,7 @@ Run inferencing using a pre-packaged audio file.
 ```
 export KMS_URL=https://accconfinferencedebug.confidential-ledger.azure.com
 docker run -e KMS_URL=${KMS_URL} mcr.microsoft.com/attested-ohttp-client:latest \
-  ${TARGET_URI} --target-path ${TARGET_PATH} -F "file=@/examples/audio.mp3" \
-  -O "api-key: ${KEY}" -F "response_format=json"
+  ${TARGET_URI} -F "file=@/examples/audio.mp3" -O "api-key: ${KEY}" -F "response_format=json"
 ```
 
 Run inferencing using your own audio file by mounting the file into the container.
@@ -32,8 +30,7 @@ export INPUT_PATH=<path to your input file>
 export MOUNTED_PATH=/examples/audio.mp3
 docker run -e KMS_URL=${KMS_URL} --volume ${INPUT_PATH}:${MOUNTED_PATH} \
   mcr.microsoft.com/attested-ohttp-client:latest \
-  ${TARGET_URI} --target-path ${TARGET_PATH} -F "file=@${MOUNTED_INPUT}" \
-  -O "api-key ${KEY}" -F "response_format=json"
+  ${TARGET_URI} -F "file=@${MOUNTED_INPUT}" -O "api-key ${KEY}" -F "response_format=json"
 ```
 
 ## Building your own container image

--- a/ohttp-client/README.md
+++ b/ohttp-client/README.md
@@ -1,0 +1,50 @@
+# Attested OHTTP Client
+This repository contains a reference implementation of an attested OHTTP client for 
+Azure AI confidential inferencing.
+
+## Prerequisites 
+
+1. An AzureML endpoint with a confidential whisper model. 
+2. Docker 
+
+## Using pre-built image
+You can use pre-built attested OHTTP container images to send an inferencing request. 
+
+Set the inferencing endpoint and accessk key as follows.
+```
+export TARGET_URI=<URL for your endpoint>
+export TARGET_PATH=/v1/engines/whisper/audio/translations
+export KEY=<key for accessing the endpoint>
+```
+
+Run inferencing using a pre-packaged audio file. 
+```
+export KMS_URL=https://accconfinferencedebug.confidential-ledger.azure.com
+docker run -e KMS_URL=${KMS_URL} mcr.microsoft.com/attested-ohttp-client:latest \
+  ${TARGET_URI} --target-path ${TARGET_PATH} -F "file=@/examples/audio.mp3" \
+  -O "api-key: ${KEY}" -F "response_format=json"
+```
+
+Run inferencing using your own audio file by mounting the file into the container.
+```
+export KMS_URL=https://accconfinferencedebug.confidential-ledger.azure.com
+export INPUT_PATH=<path to your input file>
+export MOUNTED_PATH=/examples/audio.mp3
+docker run -e KMS_URL=${KMS_URL} --volume ${INPUT_PATH}:${MOUNTED_PATH} \
+  mcr.microsoft.com/attested-ohttp-client:latest \
+  ${TARGET_URI} --target-path ${TARGET_PATH} -F "file=@${MOUNTED_INPUT}" \
+  -O "api-key ${KEY}" -F "response_format=json"
+```
+
+## Building your own container image
+
+You can build you own container image using code in this repository. First, clone the repository. 
+```
+git clone https://github.com/microsoft/attested-ohttp-client
+```
+
+Next, build the docker image. 
+
+```
+docker build -f docker/Dockerfile -t attested-ohttp-client .
+```

--- a/ohttp-client/src/main.rs
+++ b/ohttp-client/src/main.rs
@@ -95,7 +95,7 @@ struct Args {
     url: String,
 
     /// Target path of the oblivious resource
-    #[arg(long, short = 'p')]
+    #[arg(long, short = 'p', default_value = "/")]
     target_path: String,
 
     /// key configuration

--- a/ohttp-server/Cargo.toml
+++ b/ohttp-server/Cargo.toml
@@ -30,7 +30,6 @@ clap = { version = "4.5.18", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.18", features = ["default", "json", "env-filter"] }
 thiserror = "1"
-backtrace = "0.3"
 uuid = { version = "1.0", features = ["v4"] }
 
 [dependencies.bhttp]

--- a/ohttp-server/src/main.rs
+++ b/ohttp-server/src/main.rs
@@ -32,63 +32,14 @@ use serde_cbor::Value;
 use serde_json::from_str;
 
 use hpke::Deserializable;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use err::ServerError;
-use tracing::{error, info, trace};
+use tracing::{error, info, instrument, trace};
 use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter, FmtSubscriber};
 use uuid::Uuid;
 
-use backtrace::Backtrace;
-
-#[derive(Serialize)]
-struct BacktraceFrame {
-    index: usize,
-    address: String,
-    name: Option<String>,
-    file: Option<String>,
-    line: Option<u32>,
-}
-
-#[derive(Serialize)]
-struct BacktraceJson {
-    frames: Vec<BacktraceFrame>,
-}
-
-fn capture_backtrace() -> BacktraceJson {
-    let bt = Backtrace::new();
-    let frames = bt
-        .frames()
-        .iter()
-        .enumerate()
-        .map(|(index, frame)| {
-            let symbols = frame.symbols();
-            BacktraceFrame {
-                index,
-                address: format!("{:p}", frame.ip()),
-                name: symbols
-                    .first()
-                    .and_then(backtrace::BacktraceSymbol::name)
-                    .map(|n| format!("{n:?}")),
-                file: symbols
-                    .first()
-                    .and_then(|s| s.filename())
-                    .map(|f| f.display().to_string()),
-                line: symbols.first().and_then(backtrace::BacktraceSymbol::lineno),
-            }
-        })
-        .collect();
-
-    BacktraceJson { frames }
-}
-
-macro_rules! error_with_backtrace {
-    ($e:expr) => {{
-        let backtrace = capture_backtrace();
-        let json_backtrace = serde_json::to_string_pretty(&backtrace).expect("Failed to serialize backtrace");
-        error!("An error occurred: {} Backtrace:\n{}", $e, json_backtrace);
-    }};
-}
+const VERSION: &str = "1.0.0";
 
 #[derive(Deserialize)]
 struct ExportedKey {
@@ -401,7 +352,7 @@ fn compute_injected_headers(headers: &HeaderMap, keys: Vec<String>) -> HeaderMap
     result
 }
 
-#[tracing::instrument(skip(headers, body, args))]
+#[instrument(skip(headers, body, args), fields(version = %VERSION))]
 async fn score(
     headers: warp::hyper::HeaderMap,
     body: warp::hyper::body::Bytes,
@@ -417,9 +368,11 @@ async fn score(
     // The KID is normally the first byte of the request
     let kid = match body.first().copied() {
         None => {
+            let error_msg = "No key found in request.";
+            error!("{error_msg}");
             return Ok(warp::http::Response::builder()
                 .status(500)
-                .body(Body::from(&b"No key found in request."[..])))
+                .body(Body::from(error_msg.as_bytes())));
         }
         Some(kid) => kid,
     };
@@ -427,18 +380,20 @@ async fn score(
     let kms_url = args.kms_url.clone().unwrap_or(DEFAULT_KMS_URL.to_string());
     let (ohttp, token) = match load_config(&maa_url, &kms_url, kid).await {
         Err(e) => {
-            error_with_backtrace!(e);
-            return Ok(warp::http::Response::builder().status(500).body(Body::from(
-                &b"Failed to get or load OHTTP configuration."[..],
-            )));
+            let error_msg = "Failed to get or load OHTTP configuration.";
+            error!("{error_msg} {e}");
+            return Ok(warp::http::Response::builder()
+                .status(500)
+                .body(Body::from(error_msg.as_bytes())));
         }
         Ok((config, token)) => match OhttpServer::new(config) {
             Ok(server) => (server, token),
             Err(e) => {
-                error_with_backtrace!(e);
-                return Ok(warp::http::Response::builder().status(500).body(Body::from(
-                    &b"Failed to get or load OHTTP configuration."[..],
-                )));
+                let error_msg = "Failed to create OHTTP server from config.";
+                error!("{error_msg} {e}");
+                return Ok(warp::http::Response::builder()
+                    .status(500)
+                    .body(Body::from(error_msg.as_bytes())));
             }
         },
     };
@@ -464,16 +419,19 @@ async fn score(
         match generate_reply(&ohttp, inject_headers, &body[..], target, target_path, mode).await {
             Ok(s) => s,
             Err(e) => {
-                error_with_backtrace!(e);
+                error!(e);
+
                 if let Ok(oe) = e.downcast::<::ohttp::Error>() {
                     return Ok(warp::http::Response::builder()
                         .status(422)
                         .body(Body::from(format!("Error: {oe:?}"))));
                 }
 
+                let error_msg = "Request error.";
+                error!("{error_msg}");
                 return Ok(warp::http::Response::builder()
                     .status(400)
-                    .body(Body::from(&b"Request error"[..])));
+                    .body(Body::from(error_msg.as_bytes())));
             }
         };
 
@@ -537,14 +495,14 @@ async fn discover(args: Arc<Args>) -> Result<impl warp::Reply, std::convert::Inf
                     .body(Vec::from(hex).into()))
             }
             Err(e) => {
-                error_with_backtrace!(e);
+                error!("{e}");
                 Ok(warp::http::Response::builder().status(500).body(Body::from(
                     &b"Invalid key configuration (check KeyConfig written to initial cache)"[..],
                 )))
             }
         },
         Err(e) => {
-            error_with_backtrace!(e);
+            error!(e);
             Ok(warp::http::Response::builder().status(500).body(Body::from(
                 &b"KID 0 missing from cache (should be impossible with local keying)"[..],
             )))
@@ -560,13 +518,12 @@ async fn main() -> Res<()> {
         .with_file(true)
         .with_line_number(true)
         .with_thread_ids(true)
-        .with_span_events(FmtSpan::FULL)
+        .with_span_events(FmtSpan::NEW)
         .json()
         .finish();
 
     // Set the subscriber as global default
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
-
     ::ohttp::init();
 
     let args = Args::parse();
@@ -584,7 +541,7 @@ async fn main() -> Res<()> {
             ],
         )
         .map_err(|e| {
-            error_with_backtrace!(e);
+            error!("{e}");
             e
         })?;
         cache.insert(0, (config, String::new())).await;

--- a/ohttp/Cargo.toml
+++ b/ohttp/Cargo.toml
@@ -46,7 +46,6 @@ bytes = "1.7.2"
 async-stream = "0.3.5"
 tokio = { version = "1.40.0", features = ["full"] }
 tracing = "0.1"
-backtrace = "0.3"
 
 [dependencies.hpke-pq]
 package = "hpke_pq"

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -13,4 +13,3 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0.63"
 tracing = "0.1"
-backtrace = "0.3"


### PR DESCRIPTION
This PR
- Refactors the client to introduce a dependency on the microsoft fork of ohttp. 
- Fixes to the client side docker CLI
- Use of enginetarget header to determine resource path