### PR TITLE
Add logging of headers when error occurs, add a test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ else ifeq ($(MODEL), whisper_aoai)
 	TARGET_PATH ?= '/v1/engines/whisper/audio/translations'
 	DEPLOYMENT ?= 'arthig-deploy20'
 	SCORING_ENDPOINT ?= 'https://arthig-ep.eastus2.inference.ml.azure.com/score'
+	APIM_ENDPOINT ?= ''
+	API_KEY ?= ''
+
 else
 	echo "Unknown model"
 endif
@@ -118,6 +121,11 @@ run-client-kms-aoai-token: service-cert
 
 run-client-kms-aoai-apim-token: service-cert
 	RUST_LOG=info cargo run --bin ohttp-client -- ${APIM_ENDPOINT} \
+	--target-path ${TARGET_PATH} -F "file=@${INPUT}" -F "response_format=json" \
+	--kms-url ${KMS} --kms-cert ./service_cert.pem -O 'api-key: ${API_KEY}'
+
+run-client-kms-aoai-apim-token-test: service-cert
+	RUST_LOG=info RUST_BACKTRACE=1 ./target/debug/ohttp-client ${APIM_ENDPOINT} \
 	--target-path ${TARGET_PATH} -F "file=@${INPUT}" -F "response_format=json" \
 	--kms-url ${KMS} --kms-cert ./service_cert.pem -O 'api-key: ${API_KEY}'
 

--- a/ohttp-client/src/main.rs
+++ b/ohttp-client/src/main.rs
@@ -5,7 +5,7 @@ use bhttp::{Message, Mode};
 use clap::Parser;
 use futures_util::{stream::unfold, StreamExt};
 use ohttp::ClientRequest;
-use reqwest::Client;
+use reqwest::{Client, Response};
 use serde::Deserialize;
 use std::{
     fs::{self, File},
@@ -323,6 +323,17 @@ async fn create_request_from_kms_config(
     ClientRequest::from_kms_config(&config, &cert)
 }
 
+fn print_response_headers(response: &Response) {
+    info!("Response headers:");
+    for (key, value) in response.headers() {
+        info!(
+            "{}: {}",
+            key,
+            std::str::from_utf8(value.as_bytes()).unwrap()
+        );
+    }
+}
+
 async fn post_request(
     url: &String,
     outer_headers: &Option<Vec<String>>,
@@ -349,16 +360,10 @@ async fn post_request(
         Ok(response) => {
             if response.status().is_success() {
                 trace!("response status: {}\n", response.status());
-                trace!("Response headers:");
-                for (key, value) in response.headers() {
-                    trace!(
-                        "{}: {}",
-                        key,
-                        std::str::from_utf8(value.as_bytes()).unwrap()
-                    );
-                }
+                print_response_headers(&response);
                 Ok(response)
             } else {
+                print_response_headers(&response);
                 let error_msg = format!(
                     "HTTP request failed with status {} and message: {}",
                     response.status(),

--- a/tests/test_parallel.sh
+++ b/tests/test_parallel.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export MODEL=whisper_aoai
+
+# Script to run make 10 times in parallel
+for i in {1..10}
+do
+    echo "$i"
+done | parallel -j 10 "make run-client-kms-aoai-apim-token-test"


### PR DESCRIPTION
The headers were not being logged for errors. Also added a test, which can be removed later after Christophs test come online. Will only move the logging of headers to the microsoft repo.